### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,5 @@
   "engines": {
     "node": ">= 0.9.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/wearefractal/gulp-coffee/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/